### PR TITLE
Added setting for afk threshold

### DIFF
--- a/src/main/java/tk/avicia/avomod/Avomod.java
+++ b/src/main/java/tk/avicia/avomod/Avomod.java
@@ -83,6 +83,7 @@ public class Avomod {
             new ConfigInput("War", "Aura Ping Color", "FF6F00", "[\\da-fA-F]+", "^[\\da-fA-F]{6}$", 6, "auraPingColor"),
             new ConfigToggle("War", "Display Weekly Warcount on Screen", "Disabled", "displayWeeklyWarcount"),
             new ConfigToggle("War", "Prevent joining wars when afk", "Enabled", "afkWarProtection"),
+            new ConfigInput("War", "Minutes until considered afk", "10", "[0-9]+", "^[0-9]+$", 3, "afkTime"),
             new ConfigToggle("Misc", "Auto /stream on World Swap", "Disabled", "autoStream"),
             new ConfigToggle("Misc", "Prevent Moving Armor/Accessories", "Disabled", "disableMovingArmor"),
             new ConfigToggle("Misc", "Make Mob Health Bars More Readable", "Enabled", "readableHealth"),

--- a/src/main/java/tk/avicia/avomod/features/WarJoinProtection.java
+++ b/src/main/java/tk/avicia/avomod/features/WarJoinProtection.java
@@ -15,7 +15,14 @@ public class WarJoinProtection {
     private static long lastAction = System.currentTimeMillis();
 
     private static boolean isAfk() {
-        return System.currentTimeMillis() - lastAction > 10000;
+        try {
+            String afkThreshold = Avomod.getConfig("afkTime");
+            int afkThresholdInt = Integer.parseInt(afkThreshold);
+            return System.currentTimeMillis() - lastAction > afkThresholdInt * 60000L;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
     }
 
     @SubscribeEvent


### PR DESCRIPTION
Closes #3 

Adds setting for afk threshold and changed the default 10 minute check to this. Default afk threshold remains at 10 minutes. 